### PR TITLE
Added hg38 support multisample pipeline

### DIFF
--- a/R/battenberg.R
+++ b/R/battenberg.R
@@ -365,7 +365,8 @@ battenberg = function(tumourname, normalname, tumour_data_file, normal_data_file
                                    outputfile=paste(tumourname, ".BAFsegmented.txt", sep=""),
                                    prior_breakpoints_file=prior_breakpoints_file,
                                    gamma=segmentation_gamma_multisample,
-                                   calc_seg_baf_option=calc_seg_baf_option)
+                                   calc_seg_baf_option=calc_seg_baf_option,
+                                   GENOMEBUILD=GENOMEBUILD)
     
   }
   

--- a/R/haplotype_external.R
+++ b/R/haplotype_external.R
@@ -319,8 +319,8 @@ call_multisample_MSAI <- function(rdsprefix, subclonesfiles, chrom_names, tumour
                                                                     MARGIN = 2, FUN = function(x) as.numeric(substr(x = x, start = 1, stop = 1))))
     
     if (length(imbalancedregions_disj[[chrom]]) > 0) {
-      # split loci by aberrated region
-      locioverlaps <- GenomicRanges::findOverlaps(query = imbalancedregions_disj[[chrom]], subject = loci)
+      # split loci by abberrated region, compare only ranges to avoid chr naming scheme mismatch
+      locioverlaps <- IRanges::findOverlaps(query = IRanges::ranges(imbalancedregions_disj[[chrom]]), subject = IRanges::ranges(loci))
       imballoci <- split(x = loci[S4Vectors::subjectHits(locioverlaps)], f = S4Vectors::queryHits(locioverlaps), drop = F)
       
       # now check for each region the GT of major allele (in imbalanced samples)

--- a/R/segmentation.R
+++ b/R/segmentation.R
@@ -413,9 +413,10 @@ segment.baf.phased = function(samplename, inputfile, outputfile, prior_breakpoin
 #' @param prior_breakpoints_file String that points to a file with prior breakpoints (from SVs for example) with chromosome and position columns (Default: NULL)
 #' @param gamma The gamma parameter controls the size of the penalty of starting a new segment during segmentation. It is therefore the key parameter for controlling the number of segments (Default 10)
 #' @param calc_seg_baf_option Various options to recalculate the BAF of a segment. Options are: 1 - median, 2 - mean, 3 - ifelse median==0 or 1, median, mean. (Default: 3)
+#' @param GENOMEBUILD Genome build upon which the 1000G SNP coordinates were obtained
 #' @author jdemeul, sd11
 #' @export
-segment.baf.phased.multisample = function(samplename, inputfile, outputfile, prior_breakpoints_file=NULL, gamma=10, calc_seg_baf_option=3) {
+segment.baf.phased.multisample = function(samplename, inputfile, outputfile, prior_breakpoints_file=NULL, gamma=10, calc_seg_baf_option=3,GENOMEBUILD) {
   ##### internal function definitions
   # Function that takes SNPs that belong to a single segment and looks for big holes between
   # each pair of SNPs. If there is a big hole it will add another breakpoint to the breakpoints data.frame
@@ -532,7 +533,8 @@ segment.baf.phased.multisample = function(samplename, inputfile, outputfile, pri
     if (nrow(BAFrawchrseg) < 50) {
       BAFsegm = matrix(data = colMeans(BAFrawchrseg[,-c(1:2)]), nrow = nrow(BAFrawchrseg), ncol = ncol(BAFrawchrseg)-2, byrow = T)
     } else {
-      res = copynumber::multipcf(data = copynumber::winsorize(data = BAFrawchrseg), Y = BAFrawchrseg, fast = T, gamma = gamma*sdev, return.est = T, normalize = F)
+      res = copynumber::multipcf(data = copynumber::winsorize(data = BAFrawchrseg, assembly = GENOMEBUILD),
+                                 Y = BAFrawchrseg, fast = T, gamma = gamma*sdev, return.est = T, normalize = F, assembly = GENOMEBUILD)
       BAFsegm = res$estimates[,-c(1:2)]
     }
     


### PR DESCRIPTION
Updated the multisample pipeline to accept both hg19 and hg38 reference genomes.
The segment.baf.phased.multisample function now uses the battenberg GENOMEBUILD parameter and passes it on to the copynumber::multipcf and copynumber::winsorize functions.

Note that this requires the use of an **hg38-compatible copynumber package**, for instance the one available via BiocManager::install("igordot/copynumber") 