### PR TITLE
Small fix for chrBorders (function: split_genome)

### DIFF
--- a/R/clonal_ascat.R
+++ b/R/clonal_ascat.R
@@ -7,7 +7,7 @@
 split_genome = function(SNPpos) {
   # look for gaps of more than 1Mb and chromosome borders
   holesOver1Mb = which(diff(SNPpos[,2])>=1000000)+1
-  chrBorders = which(diff(as.numeric(SNPpos[,1]))!=0)+1
+  chrBorders = which(diff(as.numeric(factor(SNPpos[,1],levels=unique(SNPpos[,1]))))!=0)+1
   holes = unique(sort(c(holesOver1Mb,chrBorders)))
 
   # find which segments are too small

--- a/R/prepare_wgs.R
+++ b/R/prepare_wgs.R
@@ -165,7 +165,7 @@ getBAFsAndLogRs = function(tumourAlleleCountsFile.prefix, normalAlleleCountsFile
 #' @param is.male Boolean denoting whether this sample is male (TRUE), or female (FALSE).
 #' @param problemLociFile A file containing genomic locations that must be discarded (optional).
 #' @param useLociFile A file containing genomic locations that must be included (optional).
-#' @param heterozygousFilter The cutoff where a SNP will be considered as heterozygous (default 0.01).
+#' @param heterozygousFilter The cutoff where a SNP will be considered as heterozygous (default 0.1).
 #' @author dw9, sd11
 #' @export
 generate.impute.input.wgs = function(chrom, tumour.allele.counts.file, normal.allele.counts.file, output.file, imputeinfofile, is.male, problemLociFile=NA, useLociFile=NA, heterozygousFilter=0.1) {

--- a/man/generate.impute.input.wgs.Rd
+++ b/man/generate.impute.input.wgs.Rd
@@ -33,7 +33,7 @@ generate.impute.input.wgs(
 
 \item{useLociFile}{A file containing genomic locations that must be included (optional).}
 
-\item{heterozygousFilter}{The cutoff where a SNP will be considered as heterozygous (default 0.01).}
+\item{heterozygousFilter}{The cutoff where a SNP will be considered as heterozygous (default 0.1).}
 }
 \description{
 Prepare data for impute


### PR DESCRIPTION
Fix for `chrBorders` (function: `split_genome`) so it would work for both non-numeric (e.g. "X") and numeric (e.g. 23) chromosome names.

In more details, `as.numeric(SNPpos[,1])` was working with chromosome numbers but recent versions now use chromosome names. Without the fix, `as.numeric('X')` is just `NA` so it discards all non-numeric names.

It's not causing any massive issue though: it is used [here](https://github.com/Wedge-lab/battenberg/blob/dev/R/prepare_wgs.R#L152) to create an ascat.bc-like object so logR/BAF tracks can be plotted using ASCAT.

**Edit**: also included a fix in the doc (credit: @jdemeul). 