### PR TITLE
fix README to include VariantAnnotation as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The instructions below will install the latest stable Battenberg version.
 Installing from Github requires devtools and Battenberg requires the modified copynumber package from "igordot/copynumber" and readr, gtools, splines, ggplot2, gridExtra,  RColorBrewer and ASCAT. The pipeline requires parallel and doParallel. From the command line run:
 
 ```
-R -q -e 'BiocManager::install(c("devtools", "splines", "readr", "doParallel", "ggplot2", "RColorBrewer", "gridExtra", "gtools", "parallel", "igordot/copynumber"))'
+R -q -e 'BiocManager::install(c("devtools", "splines", "readr", "doParallel", "ggplot2", "RColorBrewer", "gridExtra", "gtools", "parallel", "igordot/copynumber", "VariantAnnotation"))'
 R -q -e 'devtools::install_github("Crick-CancerGenomics/ascat/ASCAT")'
 ```
 


### PR DESCRIPTION
Installation fails without installing VariantAnnotation first -- the following is an excerpt of the log from my dockerfile 

```
#11 [8/8] RUN R -q -e 'devtools::install_github("Wedge-Oxford/battenberg")'
#11 sha256:0a67249938aad342b04bcf2d021e9a0113f1f54c85d5a2813fded990e47ad309
#11 0.787 > devtools::install_github("Wedge-Oxford/battenberg")
#11 1.811 Downloading GitHub repo Wedge-Oxford/battenberg@HEAD
#11 4.432
#11 4.432 Skipping 1 packages not available: VariantAnnotation
#11 4.763 * checking for file ~@~X/tmp/RtmpdrZ1VK/remotes767e847c8/Wedge-lab-battenberg-4368667/DESCRIPTION~@~Y ... OK
#11 4.775 * preparing ~@~XBattenberg~@~Y:
#11 4.776 * checking DESCRIPTION meta-information ... OK
#11 4.861 * checking for LF line-endings in source and make files and shell scripts
#11 4.862 * checking for empty or unneeded directories
#11 4.869 * building ~@~XBattenberg_2.2.10.tar.gz~@~Y
#11 4.947
#11 4.961 Installing package into ~@~X/usr/local/lib/R/site-library~@~Y
#11 4.961 (as ~@~Xlib~@~Y is unspecified)
#11 5.352 ERROR: dependency ~@~XVariantAnnotation~@~Y is not available for package ~@~XBattenberg~@~Y
#11 5.352 * removing ~@~X/usr/local/lib/R/site-library/Battenberg~@~Y
#11 5.365 Warning message:
#11 5.365 In i.p(...) :
#11 5.365   installation of package ~@~X/tmp/RtmpdrZ1VK/file7754208cc/Battenberg_2.2.10.tar.gz~@~Y had non-zero exit status
#11 5.365 >
#11 5.365 >
#11 DONE 5.4s 
```