### PR TITLE
write_tsv update

### DIFF
--- a/R/impute.R
+++ b/R/impute.R
@@ -134,7 +134,7 @@ combine.impute.output = function(inputfile.prefix, outputfile, is.male, imputein
   }
   # Concatenate all the regions
   impute.output = concatenateImputeFiles(inputfile.prefix, all.boundaries)
-  write.table(impute.output, file=outputfile, row.names=F, col.names=F, quote=F, sep=" ")
+  write.table(impute.output, file=outputfile, row.names=F, col.names=T, quote=F, sep=" ")
 }
 
 

--- a/R/impute.R
+++ b/R/impute.R
@@ -134,7 +134,7 @@ combine.impute.output = function(inputfile.prefix, outputfile, is.male, imputein
   }
   # Concatenate all the regions
   impute.output = concatenateImputeFiles(inputfile.prefix, all.boundaries)
-  write.table(impute.output, file=outputfile, row.names=F, col.names=T, quote=F, sep=" ")
+  write.table(impute.output, file=outputfile, row.names=F, col.names=F, quote=F, sep=" ")
 }
 
 

--- a/R/prepare_wgs.R
+++ b/R/prepare_wgs.R
@@ -345,7 +345,7 @@ gc.correct.wgs = function(Tumour_LogR_file, outfile, correlations_outfile, gc_co
   Tumor_LogR[,3] = residuals(model)
   rm(model, corrdata)
 
-  readr::write_tsv(x=Tumor_LogR[which(!is.na(Tumor_LogR[,3])), ], path=outfile)
+  readr::write_tsv(x=Tumor_LogR[which(!is.na(Tumor_LogR[,3])), ], file=outfile)
 
   if (recalc_corr_afterwards) {
     # Recalculate the correlations to see how much there is left

--- a/R/util.R
+++ b/R/util.R
@@ -78,7 +78,7 @@ read_bafsegmented = function(filename, header=T) {
 #' @param filename Filename of the file to read in
 #' @return A data frame with the imputed genotype output
 read_imputed_output = function(filename) {
-  return(readr::read_tsv(file = filename, col_names = c("snpidx", "rsidx", "pos", "ref", "alt", "hap1", "hap2"), col_types = "cciccii"))
+  return(readr::read_delim(file = filename, delim = " ", col_names = c("snpidx", "rsidx", "pos", "ref", "alt", "hap1", "hap2"), col_types = "cciccii"))
 }
 
 #' Parser for allele frequencies data


### PR DESCRIPTION
The `path` argument of `write_tsv()` is deprecated as of readr 1.4.0. Please use the `file` argument instead.